### PR TITLE
Update ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   configuration:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
- Run workflow on ubuntu-latest host to prevent workflows from stucking with error message “Error "Waiting for a runner to pick up this job”
- Add permission **packages: write** to GITHUB_TOKEN to publish packages on GitHub (see docs https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)